### PR TITLE
fix(iam): rollback default IAM policy to use relaxed conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See [basic example](examples/basic) for further information.
 
 | Name | Type |
 |------|------|
-| [aws_iam_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
+| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [utils_deep_merge_yaml.values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
 > [!IMPORTANT]
 > Variables defined in [variables-addon[-irsa|oidc].tf](variables-addon.tf) defaults to `null` to have them overridable by the addon configuration defined though the [`local.addon[_irsa|oidc].*`](main.tf) local variable with the default values defined in [addon[-irsa|oidc].tf](addon.tf).

--- a/iam.tf
+++ b/iam.tf
@@ -2,7 +2,69 @@ locals {
   irsa_policy_enabled = var.irsa_policy_enabled != null ? var.irsa_policy_enabled : coalesce(var.irsa_assume_role_enabled, false) == false
 }
 
-data "aws_iam_policy" "this" {
+data "aws_iam_policy_document" "this" {
   count = var.enabled && var.irsa_policy == null && local.irsa_policy_enabled ? 1 : 0
-  arn   = "arn:aws:iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy"
+
+  # Official documentation https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/v2.1.4/docs/iam-policy-example.json
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "elasticfilesystem:DescribeAccessPoints",
+      "elasticfilesystem:DescribeFileSystems",
+      "elasticfilesystem:DescribeMountTargets",
+      "ec2:DescribeAvailabilityZones"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    # checkov:skip=CKV_AWS_111 there is correct condition for existing Tags
+    effect = "Allow"
+
+    actions = [
+      "elasticfilesystem:CreateAccessPoint"
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:RequestTag/efs.csi.aws.com/cluster"
+      values   = ["true"]
+    }
+  }
+
+  statement {
+    # checkov:skip=CKV_AWS_111 there is correct condition for existing Tags
+    effect = "Allow"
+
+    actions = [
+      "elasticfilesystem:TagResource"
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:ResourceTag/efs.csi.aws.com/cluster"
+      values   = ["true"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "elasticfilesystem:DeleteAccessPoint"
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/efs.csi.aws.com/cluster"
+      values   = ["true"]
+    }
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ locals {
   addon_irsa = {
     (local.addon.name) = {
       irsa_policy_enabled = local.irsa_policy_enabled
-      irsa_policy         = var.irsa_policy != null ? var.irsa_policy : try(data.aws_iam_policy.this[0].policy, "")
+      irsa_policy         = var.irsa_policy != null ? var.irsa_policy : try(data.aws_iam_policy_document.this[0].json, "")
     }
   }
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

## Type of change

- [x] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

In https://github.com/lablabs/terraform-aws-eks-efs-csi-driver/releases/tag/v1.0.0 we replaced the local IAM policy with AWS managed one. The managed policy is more strict about tags that are passed within the request, i.e. when creating EFS Access Point only `efs.csi.aws.com/cluster` is allowed causing an issue when other tags need to be passed. As the underlying Helm chart allows passing additional tags via `controller.tags` we need to relax the policy to allow this feature.

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes.
-->

Deployed K8s StorageClasss provisioned by EFS CSI driver, deployed Pod with PVC using the StorageClass. Checked EFS Access Point being created after Pod creation and destroyed upon Pod removal.
